### PR TITLE
JSON for topics

### DIFF
--- a/meetings/migrations/001.sql
+++ b/meetings/migrations/001.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "meetings_topic" ADD COLUMN start_time datetime null;

--- a/meetings/models.py
+++ b/meetings/models.py
@@ -54,7 +54,7 @@ class Meeting(models.Model):
     stamp_modified = models.DateTimeField(auto_now=True)
     
     def is_future(self):
- 	return bool( self.when >=  ( datetime.datetime.now()-settings.LATE_ARRIVAL_OFFSET ) )
+        return bool( self.when >=  ( datetime.datetime.now()-settings.LATE_ARRIVAL_OFFSET ) )
  
 
     def rsvp_user_yes(self):

--- a/meetings/models.py
+++ b/meetings/models.py
@@ -101,6 +101,7 @@ class Topic(models.Model):
     embed_video = models.TextField(blank=True,null=True)
     description = models.TextField(blank=True,null=True)
     slides_link = models.URLField(verify_exists=True, blank=True, null=True)
+    start_time = models.DateTimeField(blank = True, null = True)
 
     stamp_created = models.DateTimeField(auto_now_add=True)
     stamp_modified = models.DateTimeField(auto_now=True)

--- a/meetings/urls.py
+++ b/meetings/urls.py
@@ -7,4 +7,5 @@ urlpatterns = patterns('',
     url(r'^embed_video/(?P<id>\d+)/$', embed_video, {},'embed_video'),
     (r'^rsvp_update$', 'meetings.views.rsvp_update'),
     (r'^rsvp/(?P<mid>\d+)/(?P<msg>.+)$', 'meetings.views.rsvp'),
+    url(r'(?P<meeting>\d+)/topics.json', topics_json, name="topics.json"),
 )

--- a/meetings/views.py
+++ b/meetings/views.py
@@ -78,7 +78,7 @@ def topics_json(request, meeting):
         topics.append({'title' : topic.title,
         'presenter' : topic.by.name,
         'contact_email' : topic.by.email,
-        'start_time' : '00:00:00',
+        'start_time' : meeting.when.isoformat(),
         'duration' : topic.length,
         'description': topic.description,
         'released' : True,

--- a/meetings/views.py
+++ b/meetings/views.py
@@ -6,6 +6,7 @@ from django.contrib.auth.decorators import login_required
 from meetings.models import MeetingRsvp, Meeting
 from datetime import *
 from django.contrib import messages
+import simplejson
 
 def embed_video(request,id):
     topic = get_object_or_404(Topic, pk=id)
@@ -70,4 +71,18 @@ def rsvp_update(request):
 
     return HttpResponse(str(ok))
 
+def topics_json(request, meeting):
+    meeting = get_object_or_404(Meeting, pk=meeting)
+    topics = []
+    for topic in meeting.topic_set.all():
+        topics.append({'title' : topic.title,
+        'presenter' : topic.by.name,
+        'contact_email' : topic.by.email,
+        'start_time' : '00:00:00',
+        'duration' : topic.length,
+        'description': topic.description,
+        'released' : True,
+        })
+
+    return HttpResponse(simplejson.dumps(topics), mimetype="application/json")
 

--- a/meetings/views.py
+++ b/meetings/views.py
@@ -76,9 +76,9 @@ def topics_json(request, meeting):
     topics = []
     for topic in meeting.topic_set.all():
         topics.append({'title' : topic.title,
-        'presenter' : topic.by.name,
-        'contact_email' : topic.by.email,
-        'start_time' : meeting.when.isoformat(),
+        'presenter' : topic.by.name if topic.by else '',
+        'contact_email' : topic.by.email if topic.by else '',
+        'start_time' : topic.start_time.isoformat() if topic.start_time else '',
         'duration' : topic.length,
         'description': topic.description,
         'released' : True,


### PR DESCRIPTION
Attempting to fix #23

So I noticed that you have models in there for topics and such. I've stuck some JSON in front of it. I just want an opinion on how I should handle starttime for a topic.
### Options
1. There is no order, so I can randomly assign an order and extrapolate a start time. This probably makes the start time useless to Carl.
2. Add order field to topics. I don't see where to put a migration, so I'm assuming you're not using South? If I do this, do you want to have verification that the order is unique among topic in the same meeting. So, put in the code so that there aren't two topics with order of 1.
