### PR TITLE
added previously missing django-piston to requirements/base.txt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -57,5 +57,6 @@ django-attachments==0.3.1
 django-markup==0.3
 django-groups==0.1.dev10
 django-tagging-ext==0.2.0
+django-piston==0.2.3
 
 PIL==1.1.7


### PR DESCRIPTION
_NOTE_

I ran into the below issue caused by django-piston when running syncdb.  It's resolved by adding an empty **init**.py file to .env/Lib/site-packages/piston. (Documented here - https://bitbucket.org/jespern/django-piston/issue/173/attributeerror-module-object-has-no)

Partial trace...

(venv)malcolm@ubuntu:~/projects/Chipy$ python manage.py syncdb
Traceback (most recent call last):
  File "manage.py", line 31, in <module>
    execute_from_command_line()
 ...
  File "/home/malcolm/projects/Chipy/venv/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 176, in translation
    default_translation = _fetch(settings.LANGUAGE_CODE)
  File "/home/malcolm/projects/Chipy/venv/local/lib/python2.7/site-packages/django/utils/translation/trans_real.py", line 160, in _fetch
    apppath = os.path.join(os.path.dirname(app.__file__), 'locale')
AttributeError: 'module' object has no attribute '**file**'
